### PR TITLE
Include private events on the calendar if the current user has the capability to view them

### DIFF
--- a/EED_Espresso_Calendar.module.php
+++ b/EED_Espresso_Calendar.module.php
@@ -647,6 +647,10 @@ class EED_Espresso_Calendar extends EED_Module
                 $public_event_stati[] = strtolower(str_replace(' ', '_', $custom_post_status));
             }
         }
+        // Add private events if the current user can view them.
+        if ( EE_Registry::instance()->CAP->current_user_can('ee_read_private_events', 'get_events')) {
+            $public_event_stati[] = EEM_Event::post_status_private;
+        }
         $where_params['Event.status'] = array(
             'IN',
             apply_filters(

--- a/EED_Espresso_Calendar.module.php
+++ b/EED_Espresso_Calendar.module.php
@@ -648,7 +648,7 @@ class EED_Espresso_Calendar extends EED_Module
             }
         }
         // Add private events if the current user can view them.
-        if ( EE_Registry::instance()->CAP->current_user_can('ee_read_private_events', 'get_events')) {
+        if (EE_Registry::instance()->CAP->current_user_can('ee_read_private_events', 'get_events')) {
             $public_event_stati[] = EEM_Event::post_status_private;
         }
         $where_params['Event.status'] = array(


### PR DESCRIPTION
## Problem this Pull Request solves
See: https://events.codebasehq.com/projects/event-espresso/tickets/9788
And: https://eventespresso.com/topic/private-events-in-calendar/

## How has this been tested
Set an event to be private.

View the calendar whilst not logged into the site, that event should not be viewable.

View the calendar whilst logged in as a subscriber, again, the event should not be viewable.

Update your user account to have the `ee_read_private_events` events cap, the event should now be viewable.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
