### PR TITLE
New filter to customize retrieved event list

### DIFF
--- a/EED_Espresso_Calendar.module.php
+++ b/EED_Espresso_Calendar.module.php
@@ -880,7 +880,7 @@ class EED_Espresso_Calendar extends EED_Module
 
                 $calendar_datetime = apply_filters('FHEE__EE_Calendar__get_calendar_events__calendar_datetime', $calendar_datetime, $datetime);
 
-                if ($calendar_datetime instanceof EE_Datetime_In_Calendar) { 
+                if ($calendar_datetime instanceof EE_Datetime_In_Calendar) {
                     $calendar_datetimes_for_json [] = $calendar_datetime->to_array_for_json();
                 }
 

--- a/EED_Espresso_Calendar.module.php
+++ b/EED_Espresso_Calendar.module.php
@@ -880,7 +880,7 @@ class EED_Espresso_Calendar extends EED_Module
 
                 $calendar_datetime = apply_filters('FHEE__EE_Calendar__get_calendar_events__calendar_datetime', $calendar_datetime, $datetime);
 
-                if ( $calendar_datetime ) { 
+                if ($calendar_datetime instanceof EE_Datetime_In_Calendar) { 
                     $calendar_datetimes_for_json [] = $calendar_datetime->to_array_for_json();
                 }
 

--- a/EED_Espresso_Calendar.module.php
+++ b/EED_Espresso_Calendar.module.php
@@ -678,6 +678,17 @@ class EED_Espresso_Calendar extends EED_Module
         );
         /* @var $datetime_objs EE_Datetime[] */
 
+        $datetime_objs = apply_filters(
+            'FHEE__EED_Espresso_Calendar__get_calendar_events__query_results',
+            $datetime_objs,
+            $category_id_or_slug,
+            $venue_id_or_slug,
+            $public_event_stati,
+            $start_date,
+            $end_date,
+            $show_expired
+        );
+
         //  $this->timer->stop();
         //  echo $this->timer->get_elapse( __LINE__ );
 
@@ -869,7 +880,9 @@ class EED_Espresso_Calendar extends EED_Module
 
                 $calendar_datetime = apply_filters('FHEE__EE_Calendar__get_calendar_events__calendar_datetime', $calendar_datetime, $datetime);
 
-                $calendar_datetimes_for_json [] = $calendar_datetime->to_array_for_json();
+                if ( $calendar_datetime ) { 
+                    $calendar_datetimes_for_json [] = $calendar_datetime->to_array_for_json();
+                }
 
                 //          $this->timer->stop();
                 //          echo $this->timer->get_elapse( __LINE__ );


### PR DESCRIPTION
New filter to customize the retrieved event list, allowing full customization of the list obtained from the database, allowing the dynamic generation of events, or the removal of specific events.

Also, allowing the cancellation of the insertion of a event into the JSON if the already existing filter FHEE__EE_Calendar__get_calendar_events__calendar_datetime returns false.


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves

We need to create events dynamically. Also, we need to filter out some of the retrieved events on conditions that must be evaluated in PHP (cannot be determined by a simple SQL query).

Also, we need to allow discarding some events depending on their calculated text just before inserting them into the returned JSON.

## How has this been tested

The change introduces a new filter to allow further customization of the retrieved JSON event list. Unless this filter is used, no extra changes will happen.

<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [] My code has proper inline documentation.
