### PR TITLE
New filter: customize $calendar_datetime object

### DIFF
--- a/EED_Espresso_Calendar.module.php
+++ b/EED_Espresso_Calendar.module.php
@@ -691,7 +691,10 @@ class EED_Espresso_Calendar extends EED_Module
         foreach ($datetime_objs as $datetime) {
             if ($datetime instanceof EE_Datetime) {
                 /* @var $datetime EE_Datetime */
-                $calendar_datetime = new EE_Datetime_In_Calendar($datetime);
+                $calendar_datetime = apply_filters(
+                        'FHEE__EED_Espresso_Calendar__get_calendar_events__new_datetime_object',
+                        new EE_Datetime_In_Calendar($datetime)
+                );
                 //  $this->timer->start();
                 $event = $datetime->event();
                 /* @var $event EE_Event */

--- a/EED_Espresso_Calendar.module.php
+++ b/EED_Espresso_Calendar.module.php
@@ -692,8 +692,9 @@ class EED_Espresso_Calendar extends EED_Module
             if ($datetime instanceof EE_Datetime) {
                 /* @var $datetime EE_Datetime */
                 $calendar_datetime = apply_filters(
-                        'FHEE__EED_Espresso_Calendar__get_calendar_events__new_datetime_object',
-                        new EE_Datetime_In_Calendar($datetime)
+                    'FHEE__EED_Espresso_Calendar__get_calendar_events__new_datetime_object',
+                    new EE_Datetime_In_Calendar($datetime),
+                    $datetime
                 );
                 //  $this->timer->start();
                 $event = $datetime->event();


### PR DESCRIPTION
Added new filter that enables the further customization of $calendar_datetime object, for example by using a derived custom class.


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
We'd like to further customize the generated $calendar_datetime object, adding data in the object initialization that links the event with data from other plugins. This data will be processed used by other filters in the method.

## How has this been tested
It's just a new filter. It doesn't affect the current code base unless the filter is used as a new hook for a new callback.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
