### PR TITLE
Add hooks in Javascript layer to enable customizations of calendar

### DIFF
--- a/EED_Espresso_Calendar.module.php
+++ b/EED_Espresso_Calendar.module.php
@@ -242,7 +242,7 @@ class EED_Espresso_Calendar extends EED_Module
         }
         // core calendar script
         wp_register_script('fullcalendar-min-js', EE_CALENDAR_URL . 'scripts' . DS . 'fullcalendar.min.js', array( 'jquery' ), '1.6.2', true);
-        wp_register_script('espresso_calendar', EE_CALENDAR_URL . 'scripts' . DS . 'espresso_calendar.js', array( 'fullcalendar-min-js' ), EE_CALENDAR_VERSION, true);
+        wp_register_script('espresso_calendar', EE_CALENDAR_URL . 'scripts' . DS . 'espresso_calendar.js', array( 'fullcalendar-min-js', 'wp-hooks' ), EE_CALENDAR_VERSION, true);
 
         // get the current post
         global $post, $is_espresso_calendar;

--- a/scripts/espresso_calendar.js
+++ b/scripts/espresso_calendar.js
@@ -176,7 +176,7 @@ jQuery(document).ready(function($) {
                 iframe: eeCAL.iframe
 			};
 //			console.log( cal_data );
-			$.ajax({
+			$.ajax( wp.hooks.applyFilters( 'FHEE__EED_Espresso_Calendar__event_ajax_params', {
 				url: eeCAL.ajax_url,
 				dataType: 'json',
 				data: cal_data,
@@ -217,7 +217,7 @@ jQuery(document).ready(function($) {
 				},
 				error: function(response) {
 				}
-			});
+			}));
 		},
 		// A hook for modifying a day cell.
 		dayRender: function( date, cell ) {
@@ -305,7 +305,7 @@ jQuery(document).ready(function($) {
 			}
 
 			if ( eeCAL.tooltip_show ) {
-				element.qtip({
+				element.qtip( wp.hooks.applyFilters( 'FHEE__EED_Espresso_Calendar__tooltip_params', {
 					content: {
 						text: event.description + event.tooltip,
 						title: event.title,
@@ -326,7 +326,7 @@ jQuery(document).ready(function($) {
 						classes: event.tooltip_style,
 						widget: true
 					}
-				});
+				}));
 
 			} else {
 				//This displays the title of the event when hovering
@@ -344,6 +344,7 @@ jQuery(document).ready(function($) {
 				$espresso_calendar.fullCalendar( 'refetchEvents' );
 				eeCAL.events_per_day = {};
 			}
+			wp.hooks.doAction('FHEE__EED_Espresso_Calendar__viewRender_action', view, eeCAL);
 		},
 		// viewDestroy : function( view, element ) {
 //			console.log( ' ' );


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
This PR allows the full customization of the calendar component.

## How has this been tested

I'm working on a plugin that integrates the Event Calendar with other plugins from the site, and these changes were needed in order to customize the calendar's behaviour.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
