### PR TITLE
require wp-hooks-js for iframe, it's needed now with the changes in #12

### DIFF
--- a/CalendarIframe.php
+++ b/CalendarIframe.php
@@ -46,6 +46,7 @@ class CalendarIframe extends Iframe
      */
     public function display($utm_content = 'events_calendar')
     {
+        global $wp_version;
         $this->addStylesheets(
             apply_filters(
                 'FHEE__CalendarIframe__display__css',
@@ -60,6 +61,7 @@ class CalendarIframe extends Iframe
             apply_filters(
                 'FHEE__CalendarIframe__display__js',
                 array(
+                    'wp-hooks'            => includes_url('js/dist/hooks.min.js?ver=' . $wp_version),
                     'fullcalendar-min-js' => EE_CALENDAR_URL . 'scripts' . DS . 'fullcalendar.min.js?ver=1.6.2',
                     'espresso_calendar'   => EE_CALENDAR_URL . 'scripts' . DS
                                              . 'espresso_calendar.js?ver=' . EE_CALENDAR_VERSION,


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Calendar iFrame no longer loads with the new version of the calendar add-on. This is the error in the console:
`Uncaught ReferenceError: wp is not defined`
Related PR #12 
## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Activate calendar add-on, then go to {site url}?calendar=iframe
Calendar should populate events as expected

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
