### PR TITLE
Filter the ee_terms used by the calendar 'filters' (options to filter events on the front end of the calendar)

### DIFF
--- a/EED_Espresso_Calendar.module.php
+++ b/EED_Espresso_Calendar.module.php
@@ -275,10 +275,19 @@ class EED_Espresso_Calendar extends EED_Module
         $output_filter = '';
         if (! $ee_calendar_js_options['widget']) {
             // Query for Select box filters
-            $ee_terms = EEM_Term::instance()->get_all(array(
-                'order_by' => array( 'name' => 'ASC' ),
-                array( 'Term_Taxonomy.taxonomy' => 'espresso_event_categories',
-            ) ));
+            $ee_terms = EEM_Term::instance()->get_all( 
+                array(
+                    'order_by' => array( 'name' => 'ASC' ),
+                    array( 'Term_Taxonomy.taxonomy' => 'espresso_event_categories')
+                )
+            );
+            // Filter the terms
+            $ee_terms = apply_filters(
+                'FHEE__EE_Calendar___get_filter_html__ee_terms',
+                $ee_terms,
+                $ee_calendar_js_options
+            );
+
             $venues = EEM_Venue::instance()->get_all(array( 'order_by' => array( 'VNU_name' => 'ASC' ) ));
 
             if (! empty($venues) || !empty($ee_terms)) {

--- a/EED_Espresso_Calendar.module.php
+++ b/EED_Espresso_Calendar.module.php
@@ -275,7 +275,7 @@ class EED_Espresso_Calendar extends EED_Module
         $output_filter = '';
         if (! $ee_calendar_js_options['widget']) {
             // Query for Select box filters
-            $ee_terms = EEM_Term::instance()->get_all( 
+            $ee_terms = EEM_Term::instance()->get_all(
                 array(
                     'order_by' => array( 'name' => 'ASC' ),
                     array( 'Term_Taxonomy.taxonomy' => 'espresso_event_categories')


### PR DESCRIPTION
See here: https://eventespresso.com/topic/event_category_idxxyyzz-doesnt-limit-the-display-to-the-category/

In short, the user passing category ids (or slugs) to the calendar shortcode but then the filters continue to show all categories above the calendar. I chose not to change the default behaviour here and went with a filter on the terms only.

## How has this been tested
With this branch, load the calendar and check all your categories show on the filters (enable the filters in the calendar settings).

On the calendar shortcode set the `event_category_id=xx,yy,zz` paramters were your passing either category ID's, category slugs or a mixture of both (User's really shouldn't be passing a mixture, but its possible).

That should limit the calendar to only show events in whatever categories you set on the parameter, but the category dropdown and legend will still show all of them.

Add this filter to your site: https://gist.github.com/Pebblo/d65be156ca1cc812e5eb022ccf0d0adf

Now the dropdown and legend should only show the categories you passed in the shortcode.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
